### PR TITLE
S3 doesn't have a global region

### DIFF
--- a/console-services.yml
+++ b/console-services.yml
@@ -1884,7 +1884,7 @@
   name: Simple Storage Service
   short_name: S3
   description: Scalable Storage in the Cloud
-  has_global_region: true
+  has_global_region: false
   url: /s3/home
   sub_services:
     - id: buckets


### PR DESCRIPTION
I don't believe that S3 has a global region. 

The URL will change from:
https://console.aws.amazon.com/s3/home

to this for example:
https://eu-west-1.console.aws.amazon.com/s3/home

Maybe this breaks something I've not come across however?